### PR TITLE
 Fix Window.onDeactivate

### DIFF
--- a/src/core/sdl2/SDLApplication.cpp
+++ b/src/core/sdl2/SDLApplication.cpp
@@ -1583,7 +1583,7 @@ void TVPWindowLayer::InvalidateClose() {
 	delete this;
 }
 bool TVPWindowLayer::GetWindowActive() {
-	return _currentWindowLayer == this;
+	return _currentWindowLayer == this && SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS;
 }
 void TVPWindowLayer::OnClose(CloseAction& action) {
 	if (modal_result_ == 0)


### PR DESCRIPTION
Currently Window.onDeactivate handlers are never triggered because
tTJSNI_BaseWindow::OnActivate() dispatches events only if the active
status is different from the return value of GetWindowActive(), but
TVPWindowLayer::GetWindowActive() in SDLApplication.cpp always returns
true.

This makes GetWindowActive() return false when the window is unfocused.