### PR TITLE
Run linker with optimization flags for Emscripten

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,7 @@ if target_machine.system() == 'emscripten'
 		'-s', 'FORCE_FILESYSTEM=1',
 		'-s', 'ASSERTIONS=0',
 		'-s', 'STACK_OVERFLOW_CHECK=0',
+		'-O@0@'.format(get_option('optimization')),
 		'-lidbfs.js',
 		'--bind',
 		'--no-heap-copy',


### PR DESCRIPTION
Thank you for your work on this project.

It is possible to improve binary size and performance for the web build by passing the optimization level to emcc when linking. By default, it seems that meson does not pass the configured optimization level to the linker. emcc will run post-linker optimizations such as wasm-opt when optimization is configured during linking. 

Here is a binary size comparison:
```bash
# meson 0.63.0, emcc 2.0.9
# before patch:
[netdex@rml build]$ ls -lh krkrsdl2.{js,wasm}
-rw-r--r-- 1 netdex netdex 474K Aug 14 20:19 krkrsdl2.js
-rwxr-xr-x 1 netdex netdex 6.6M Aug 14 20:19 krkrsdl2.wasm
# after patch:
[netdex@rml build]$ ls -lh krkrsdl2.{js,wasm}
-rw-r--r-- 1 netdex netdex 259K Aug 14 20:19 krkrsdl2.js
-rwxr-xr-x 1 netdex netdex 5.0M Aug 14 20:19 krkrsdl2.wasm
```