### PR TITLE
Supports Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@
       ]
     },
     "build-macos-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "strategy" : {
         "fail-fast" : false,
@@ -390,7 +390,10 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build ${{ matrix.appbundle.cmakeflags }}"
+          "run" : "cmake -S . -B build ${{ matrix.appbundle.cmakeflags }}",
+          "env" : {
+             "CMAKE_OSX_ARCHITECTURES":"x86_64;arm64"
+          }
         },
         {
           "name" : "Build project",
@@ -417,7 +420,7 @@
       ]
     },
     "build-ios-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "steps" : [
         {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ endif()
 
 if(APPLE AND NOT IOS)
 set(MACOS_RESOURCES_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src/resources/macos CACHE FILEPATH "The path to the resources for macOS.")
+add_compile_options(-Wno-declaration-after-statement)
 endif()
 
 if(VITA)


### PR DESCRIPTION
Because of matter of the version of MacOS used in CI,The output is not a universal binary.
This change updates CI

I haven't verified if kirikiri plugins work,Maybe I should make pull requests for plugins to make universal binary.

![image](https://github.com/krkrsdl2/krkrsdl2/assets/58556570/ce5669f0-11dd-40c1-80d6-68db7541ddb9)

- about the diff of CMakeLists

Without the diff of CMakeLists.txt,I got this error message on CI

> mixing declarations and code is incompatible with standards before C99
