### PR TITLE
Update ci.yml for x86_64 MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,10 +390,7 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build ${{ matrix.appbundle.cmakeflags }}",
-          "env" : {
-             "CMAKE_OSX_ARCHITECTURES":"x86_64;arm64"
-          }
+          "run" : "cmake -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' -S . -B build ${{ matrix.appbundle.cmakeflags }}"
         },
         {
           "name" : "Build project",


### PR DESCRIPTION
Sorry. I misplaced the cmake option in the env. Due to the MacOS version, my PR made binary do not work on a Mac with x64.

This PR creates a universal binary correctly. This will allow krkrsdl2 to work in x86_64 MacOS environment.

![image](https://github.com/krkrsdl2/krkrsdl2/assets/58556570/567b5be0-651b-4fdd-b8bf-21bfd23f4b03)
